### PR TITLE
Updates correct location to find "ProjectConfigurator.exe" file

### DIFF
--- a/doc_source/gems-system-gems-testing.md
+++ b/doc_source/gems-system-gems-testing.md
@@ -6,7 +6,7 @@ After you move your assets into the gem's directory structure, you can enable yo
 
 1. Open the Project Configurator by doing one of the following:
    + Open Lumberyard Setup Assistant\. On the **Summary** page, click **Configure project**\.
-   + Navigate to the `lumberyard_version\dev\Tools\LmbrSetup\Win\` directory and then start `ProjectConfigurator`\.
+   + Navigate to the `lumberyard_version\dev\Bin64vc140\` directory (if using Visual Studio 2015), or the `lumberyard_version\dev\Bin64vc141\` directory (if using Visual Studio 2017) directory and then start `ProjectConfigurator`\.
 
 1. [Enable](gems-system-using-project-configurator.md) your new Gem\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

ProjectConfigurator.exe is located in lumberyard_version\dev\Bin64vc140 for VS2015 and lumberyard_version\dev\Bin64vc141 for VS2017.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
