### PR TITLE
Additional Information for Asset Setup

### DIFF
--- a/doc_source/gems-system-gems-packaging.md
+++ b/doc_source/gems-system-gems-packaging.md
@@ -2,7 +2,11 @@
 
 Before you can include your assets in your new gem, you must place them within your Lumberyard's game project root directory\. This way, they will be imported by Lumberyard Asset Pipeline and converted into assets that Lumberyard can use\. After you move and import your assets, you must test them in Lumberyard to ensure that they still work as intended\. You then move the verified assets into the gem directory structure that was created when you created a new gem\.
 
-It is recommended to use a namespace workflow or acronyms in folders for assets within gems in order to avoid conflicts with similarly named assets. For example, adding an additional directory between `Assets` and `Textures` will avoid conflicts for other gems that may have identically named textures, so your structure will look something like `\dev\Gems\gem_name\Assets\gem_name\Textures\CommonTextureName.TIF`
+**Note**  
+To avoid conflicts with similarly named assets, we recommend that you use a namespace workflow or acronyms when you create directories that contain assets in gems. 
+
+For example, you can add a directory between `Assets` and `Textures` so that the directory doesn't conflict with other gems that might have identically named textures. Your structure might look like the following: 
+`lumberyard_version\dev\Gems\gem_name\Assets\example_name\Textures\CommonTextureName.tif`
 
 **To package your assets**
 

--- a/doc_source/gems-system-gems-packaging.md
+++ b/doc_source/gems-system-gems-packaging.md
@@ -2,6 +2,8 @@
 
 Before you can include your assets in your new gem, you must place them within your Lumberyard's game project root directory\. This way, they will be imported by Lumberyard Asset Pipeline and converted into assets that Lumberyard can use\. After you move and import your assets, you must test them in Lumberyard to ensure that they still work as intended\. You then move the verified assets into the gem directory structure that was created when you created a new gem\.
 
+It is recommended to use a namespace workflow or acronyms in folders for assets within gems in order to avoid conflicts with similarly named assets. For example, adding an additional directory between `Assets` and `Textures` will avoid conflicts for other gems that may have identically named textures, so your structure will look something like `\dev\Gems\gem_name\Assets\gem_name\Textures\CommonTextureName.TIF`
+
 **To package your assets**
 
 1. Prepare your asset directory\.


### PR DESCRIPTION
Because of the way relative pathing is set up for Gems, users may encounter a scenario where they have conflicting assets because they are in the same location with the same name within their respective gems. It is worth noting that by adding other namespaces, folders, etc. it can help make their content less likely to have a conflict with other content.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
