### PR TITLE
Add missing 'be'

### DIFF
--- a/doc_source/ebus-in-depth.md
+++ b/doc_source/ebus-in-depth.md
@@ -17,7 +17,7 @@ You can use EBuses in many different ways\. Following are some examples:
 +  For queued delivery
 +  Automatic marshalling of a function call into a network message or other command buffer
 
-The EBus source code can found in the Lumberyard directory location `<root>\dev\Code\Framework\AZCore\AZCore\EBus\EBus.h`\.
+The EBus source code can be found in the Lumberyard directory location `<root>\dev\Code\Framework\AZCore\AZCore\EBus\EBus.h`\.
 
 ## Bus Configurations<a name="ebus-in-depth-configuration"></a>
 


### PR DESCRIPTION
Description of changes: 
Added a missing 'be' in 'can be found.'


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
