### PR TITLE
Changed `BusName.CreateHandler()` to `BusName.Connect()`

### DIFF
--- a/doc_source/asset-bundler-migrating.md
+++ b/doc_source/asset-bundler-migrating.md
@@ -43,6 +43,8 @@ After you generate asset bundles to deliver with your game, switch your release 
 
    1. Create a customized batch file\. You can use the file `Build_AssetBundler_AuxiliaryContent_PC.bat` as a template and update the operating system\. You also must update the reference to the RC config file to point to the file that you created in the previous step\.
 
+      [Download](https://d1a5h15s88ekwk.cloudfront.net/1.22.0.0/scripts/Build_AssetBundler_AuxiliaryContent_PC.bat) the `Build_AssetBundler_AuxiliaryContent_PC.bat` if it is not available\.
+
    1. Run the customized batch file to generate auxiliary data and the asset bundles\.
 
    1. Add the new bundle files to the directory `gamename_platform_paks/gamename`\. You can do this manually or create custom scripts based on the samples described in the next section\.

--- a/doc_source/asset-bundler-starter-game-tutorial-step4.md
+++ b/doc_source/asset-bundler-starter-game-tutorial-step4.md
@@ -4,6 +4,8 @@ Generate the auxiliary data, and move that data into your release build bundle d
 
 1. Open a command prompt\. Run the following batch file to generate the auxiliary data that you need to finish preparing your bundle: `Build_AssetBundler_AuxiliaryContent_PC.bat --game StarterGame`
 
+   [Download](https://d1a5h15s88ekwk.cloudfront.net/1.22.0.0/scripts/Build_AssetBundler_AuxiliaryContent_PC.bat) the `Build_AssetBundler_AuxiliaryContent_PC.bat` if it is not available\.
+
    Running this file places the auxiliary data into a directory called `startergame_pc_paks` under `{Lumberyard Install Root Directory here}\dev`\.
 
 1. Copy the contents of `startergame_pc_paks` into your `startergame` release build subdirectory\.   

--- a/doc_source/asset-bundler-tutorial-simple.md
+++ b/doc_source/asset-bundler-tutorial-simple.md
@@ -99,6 +99,8 @@ Build the shader assets and auxiliary data for your game and add them to your re
    Build_AssetBundler_AuxiliaryContent_PC.bat --game <AssetBundlingDemo>
    ```
 
+   [Download](https://d1a5h15s88ekwk.cloudfront.net/1.22.0.0/scripts/Build_AssetBundler_AuxiliaryContent_PC.bat) the `Build_AssetBundler_AuxiliaryContent_PC.bat` if it is not available\.
+   
    Auxiliary data is generated in the directory `{Lumberyard Install Root Directory here}\dev\<AssetBundlingDemo>_pc_paks`\.
 
 1. Copy the contents of `<AssetBundlingDemo>_pc_paks` into the root of the game content subfolder of the release bundle that you created in the previous section\.

--- a/doc_source/component-entity-system-gameplay-bus.md
+++ b/doc_source/component-entity-system-gameplay-bus.md
@@ -82,7 +82,7 @@ local InLavaBehavior ={
 
 function InLavaBehavior:OnActivate()
     local gameplayId = GameplayNotificationId(self.entityId, "InLava")
-    self.gameplayBus = GameplayNotificationBus.CreateHandler(self, inputBusId)
+    self.gameplayBus = GameplayNotificationBus.Connect(self, inputBusId)
 end
 ```
 

--- a/doc_source/lua-scripting-ces-using-ebuses.md
+++ b/doc_source/lua-scripting-ces-using-ebuses.md
@@ -20,7 +20,7 @@ local SpawnerScriptSample = { }
 function SpawnerScriptSample:OnActivate()
     -- Register our handlers to receive notification from the spawner attached to this entity.
     if( self.spawnerNotiBusHandler == nil ) then
-        self.spawnerNotiBusHandler = SpawnerComponentNotificationBus.CreateHandler(self, self.entityId)
+        self.spawnerNotiBusHandler = SpawnerComponentNotificationBus.Connect(self, self.entityId)
     end
 end
 
@@ -63,7 +63,7 @@ The following example shows how to register with the tick bus\.
 local TestScript = { }
 function TestScript:OnActivate()
     -- Inform the tick bus that you want to receive event notifications
-    self.tickBusHandler = TickBus.CreateHandler(self)
+    self.tickBusHandler = TickBus.Connect(self)
     self.tickBusHandler:Connect()
 end
 
@@ -78,13 +78,6 @@ function TestScript:OnDeactivate()
 end
 
 return TestScript
-```
-
-**Note**  
-Instead of calling `CreateHandler` and then calling `Connect` on the handler, you can use the Lua shortcut function `TickBus.Connect`\. The `Connect` function uses the following syntax to create a handler and automatically connect the handler to the bus\.   
-
-```
-handler = TickBus.Connect(handlerTable[, connectionId])
 ```
 
 ## Sending Events to a Component<a name="lua-scripting-ces-sending-events-to-a-component"></a>


### PR DESCRIPTION
*Description of changes:*

Changed `BusName.CreateHandler()` to `BusName.Connect()`.

Reason: LY warning "[Warning] (Script) - CreateHandler function called with busId. Please change instances of BusName.CreateHandler(<table>, <id>) to BusName.Connect(<table>, <id>) to avoid loss of functionality in future releases".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
